### PR TITLE
Register sigterm for graceful shutdown

### DIFF
--- a/app.go
+++ b/app.go
@@ -159,7 +159,7 @@ func (app *App) Run() error {
 	// listen for a shutdown signal
 	go func() {
 		exitChan := make(chan os.Signal, 1)
-		signal.Notify(exitChan, os.Interrupt, os.Kill)
+		signal.Notify(exitChan, syscall.SIGINT, syscall.SIGTERM)
 		s := <-exitChan
 		log.Infof("Got shutdown signal: %v", s)
 		manners.Close()

--- a/app.go
+++ b/app.go
@@ -159,7 +159,7 @@ func (app *App) Run() error {
 	// listen for a shutdown signal
 	go func() {
 		exitChan := make(chan os.Signal, 1)
-		signal.Notify(exitChan, syscall.SIGINT, syscall.SIGTERM)
+		signal.Notify(exitChan, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 		s := <-exitChan
 		log.Infof("Got shutdown signal: %v", s)
 		manners.Close()


### PR DESCRIPTION
**Purpose**

Scroll used to exit immediately when receiving `SIGTERM` because it was not registered.
On the other hand registering `SIGKILL` doesn't make sense because the OS won't give enough time for graceful shutdown.