### PR TITLE
Fix incorrect usage of manners

### DIFF
--- a/app.go
+++ b/app.go
@@ -142,8 +142,6 @@ func (app *App) IsPublicRequest(request *http.Request) bool {
 //
 // Supports graceful shutdown on 'kill' and 'int' signals.
 func (app *App) Run() error {
-	http.Handle("/", app.router)
-
 	// toggle heartbeat on SIGUSR1
 	go func() {
 		app.heartbeater.Start()
@@ -166,7 +164,7 @@ func (app *App) Run() error {
 	}()
 
 	addr := fmt.Sprintf("%v:%v", app.Config.ListenIP, app.Config.ListenPort)
-	return manners.ListenAndServe(addr, nil)
+	return manners.ListenAndServe(addr, app.router)
 }
 
 // registerLocation is a helper for registering handlers in vulcan.


### PR DESCRIPTION
### Problem

Scroll assumed that `manners` server used the default http router, but that has not been promised by `manners`. As a result when manners started to use non-default router, `scroll` broke.

### Implementation

Make scroll explicitly provide a router to the instance of `manners` server.