### PR TITLE
Input sanitation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -55,9 +55,17 @@ func (e ConflictError) Error() string {
 	return e.Description
 }
 
+type UnsafeFieldError struct {
+	Field string
+}
+
+func (e UnsafeFieldError) Error() string {
+	return fmt.Sprintf("field contains unsafe characters: %v", e.Field)
+}
+
 func responseAndStatusFor(err error) (Response, int) {
 	switch err.(type) {
-	case GenericAPIError, MissingFieldError, InvalidFormatError, InvalidParameterError:
+	case GenericAPIError, MissingFieldError, InvalidFormatError, InvalidParameterError, UnsafeFieldError:
 		return Response{"message": err.Error()}, http.StatusBadRequest
 	case NotFoundError:
 		return Response{"message": err.Error()}, http.StatusNotFound

--- a/fields.go
+++ b/fields.go
@@ -18,6 +18,21 @@ func GetStringField(r *http.Request, fieldName string) (string, error) {
 	return r.FormValue(fieldName), nil
 }
 
+// Retrieves requested field as a string, allowSet provides input sanitization. If an
+// error occurs, returns either a `MissingFieldError` or an `UnsafeFieldError`.
+func GetStringFieldSafe(r *http.Request, fieldName string, allowSet AllowSet) (string, error) {
+	if _, ok := r.Form[fieldName]; !ok {
+		return "", MissingFieldError{fieldName}
+	}
+
+	fieldValue := r.FormValue(fieldName)
+	if !allowSet.IsSafe(fieldValue) {
+		return "", UnsafeFieldError{fieldName}
+	}
+
+	return fieldValue, nil
+}
+
 // Retrieve a POST request field as a string.
 // If the requested field is missing, returns provided default value.
 func GetStringFieldWithDefault(r *http.Request, fieldName, defaultValue string) string {

--- a/fields_test.go
+++ b/fields_test.go
@@ -11,6 +11,26 @@ type FieldsSuite struct{}
 
 var _ = Suite(&FieldsSuite{})
 
+func (s *FieldsSuite) TestSafe(c *C) {
+	request, _ := http.NewRequest("GET", "http://example.com", nil)
+	request.Form = make(url.Values)
+	request.Form["p"] = []string{"foo"}
+
+	value, err := GetStringFieldSafe(request, "p", NewAllowSetBytes("f", 3))
+	c.Assert(err, NotNil)
+
+	value, err = GetStringFieldSafe(request, "p", NewAllowSetBytes("fo", 3))
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "foo")
+
+	value, err = GetStringFieldSafe(request, "p", NewAllowSetStrings([]string{"bar", "baz"}))
+	c.Assert(err, NotNil)
+
+	value, err = GetStringFieldSafe(request, "p", NewAllowSetStrings([]string{"foo", "bar"}))
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "foo")
+}
+
 func (s *FieldsSuite) TestGetMultipleFields(c *C) {
 	request, _ := http.NewRequest("GET", "http://example.com", nil)
 	request.Form = make(url.Values)

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,60 @@
+package scroll
+
+import "unicode"
+
+// The AllowSet interface is implemented to detect if input is safe or not.
+type AllowSet interface {
+	IsSafe(string) bool
+}
+
+// AllowSetBytes allows the definition of a set of safe allowed ASCII characters.
+// AllowSetBytes does not support unicode code points. If you pass the
+// string "ü" (which encodes as 0xc3 0xbc) they will be skipped over.
+type AllowSetBytes struct {
+	maxLen int
+	chars  [256]bool
+}
+
+func NewAllowSetBytes(s string, maxlen int) AllowSetBytes {
+	var as [256]bool
+	for i := 0; i < len(s); i++ {
+		if s[i] <= unicode.MaxASCII {
+			as[s[i]] = true
+		}
+	}
+	return AllowSetBytes{maxLen: maxlen, chars: as}
+}
+
+func (a AllowSetBytes) IsSafe(s string) bool {
+	if len(s) > a.maxLen {
+		return false
+	}
+
+	for i := 0; i < len(s); i++ {
+		if a.chars[s[i]] == false {
+			return false
+		}
+	}
+
+	return true
+}
+
+// AllowSetStrings allows the definition of a set of safe allowed strings.
+type AllowSetStrings struct {
+	strings map[string]bool
+}
+
+func NewAllowSetStrings(s []string) AllowSetStrings {
+	m := map[string]bool{}
+	for _, v := range s {
+		m[v] = true
+	}
+	return AllowSetStrings{strings: m}
+}
+
+func (a AllowSetStrings) IsSafe(s string) bool {
+	if _, ok := a.strings[s]; !ok {
+		return false
+	}
+	return true
+}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,0 +1,98 @@
+package scroll
+
+import (
+	"fmt"
+	"testing"
+)
+
+var _ = fmt.Printf // for testing
+
+func TestAllowSetBytes(t *testing.T) {
+	tests := []struct {
+		inString string
+		inAllow  AllowSet
+		out      bool
+	}{
+		// 0 - no match
+		{
+			"hello0",
+			NewAllowSetBytes(`0123456789`, 100),
+			false,
+		},
+		// 1 - length (input length is one more than max)
+		{
+			"hello",
+			NewAllowSetBytes(`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`, 4),
+			false,
+		},
+		// 2 - length (equal)
+		{
+			"hello",
+			NewAllowSetBytes(`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`, 5),
+			true,
+		},
+		// 3 - length (input length is one less than max)
+		{
+			"hello",
+			NewAllowSetBytes(`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`, 6),
+			true,
+		},
+		// 5 - all good
+		{
+			"hello, world",
+			NewAllowSetBytes(`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ, `, 100),
+			true,
+		},
+	}
+
+	for i, tt := range tests {
+		if g, w := tt.inAllow.IsSafe(tt.inString), tt.out; g != w {
+			t.Errorf("Test(%v), Got IsSafe: %v, Want: %v", i, g, w)
+		}
+	}
+}
+
+func TestAllowSetStrings(t *testing.T) {
+	tests := []struct {
+		inString string
+		inAllow  AllowSet
+		out      bool
+	}{
+		// 0 - no match
+		{
+			"foo",
+			NewAllowSetStrings([]string{`bar`}),
+			false,
+		},
+		// 1 - empty
+		{
+			"foo",
+			NewAllowSetStrings([]string{``}),
+			false,
+		},
+		// 2 - one less
+		{
+			"foo",
+			NewAllowSetStrings([]string{`fo`}),
+			false,
+		},
+		// 3 - one more
+		{
+			"foo",
+			NewAllowSetStrings([]string{`fooo`}),
+			false,
+		},
+		// 4 - exact match
+		{
+			"foo",
+			NewAllowSetStrings([]string{`foo`}),
+			true,
+		},
+	}
+
+	for i, tt := range tests {
+		if g, w := tt.inAllow.IsSafe(tt.inString), tt.out; g != w {
+			t.Errorf("Test(%v), Got IsSafe: %v, Want: %v", i, g, w)
+		}
+	}
+}


### PR DESCRIPTION
**Purpose**

This PR adds input sanitation functions for parsing arbitrary string input form and url values that allows input to be validated against a set of whitelisted values.

**Implementation**

* An interface `AllowSet` which implements a single method `IsSafe(string) bool` was added. Objects that implement this interface are used to validate input.
* `AllowSetBytes` and `AllowSetStrings` implement `AllowSet`. The former is set of allowed un-ordered characters while the latter is a set of ordered characters (strings).
* The following method can be called in a request handler to safely retrieve string field values: `GetStringFieldSafe`.

**Example Usage**

```
handlerAllowSet = NewAllowSetChars(`abcdefghijklmnopqrstuvwxyz`, 10)

func handler(w http.ResponseWriter, r *http.Request, params map[string]string) (interface{}, error) {
    fieldValue, err := scroll.GetStringFieldSafe(r, "foo", handlerAllowSet)
    if err != nil {
        return nil, err
    }

    return scroll.Response{"message": fmt.Sprintf("Great input: %q", fieldValue)}, nil
}
```
