### PR TITLE
Input sanitization (#2)

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -111,3 +111,10 @@ func GetDurationField(r *http.Request, fieldName string) (time.Duration, error) 
 	}
 	return d, nil
 }
+
+func HasField(r *http.Request, fieldName string) bool {
+	if _, ok := r.Form[fieldName]; !ok {
+		return false
+	}
+	return true
+}

--- a/handler.go
+++ b/handler.go
@@ -159,6 +159,24 @@ func ReplyInternalError(w http.ResponseWriter, message string) {
 	Reply(w, Response{"message": message}, http.StatusInternalServerError)
 }
 
+// GetVarSafe is a helper function that returns the requested variable from URI with allowSet
+// providing input sanitization. If an error occurs, returns either a `MissingFieldError`
+// or an `UnsafeFieldError`.
+func GetVarSafe(r *http.Request, variableName string, allowSet AllowSet) (string, error) {
+	vars := mux.Vars(r)
+	variableValue, ok := vars[variableName]
+
+	if !ok {
+		return "", MissingFieldError{variableName}
+	}
+
+	if !allowSet.IsSafe(variableValue) {
+		return "", UnsafeFieldError{variableName}
+	}
+
+	return variableValue, nil
+}
+
 // Parse the request data based on its content type.
 func parseForm(r *http.Request) error {
 	if isMultipart(r) == true {


### PR DESCRIPTION
**Purpose**

Just as with fields, provide input sanitization for URI variables. Also helper to check if field exists.

**Implementation**

* Call `GetVarSafe` to safely extract a URI variable with an `AllowSet`.
* Call `HasField` to check if a request has given field.

**Related PR**
https://github.com/mailgun/scroll/pull/28