### PR TITLE
API Change to IsSafe

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -56,11 +56,12 @@ func (e ConflictError) Error() string {
 }
 
 type UnsafeFieldError struct {
-	Field string
+	Field       string
+	Description string
 }
 
 func (e UnsafeFieldError) Error() string {
-	return fmt.Sprintf("field contains unsafe characters: %v", e.Field)
+	return fmt.Sprintf("field %q is unsafe: %v", e.Field, e.Description)
 }
 
 func responseAndStatusFor(err error) (Response, int) {

--- a/fields.go
+++ b/fields.go
@@ -26,8 +26,9 @@ func GetStringFieldSafe(r *http.Request, fieldName string, allowSet AllowSet) (s
 	}
 
 	fieldValue := r.FormValue(fieldName)
-	if !allowSet.IsSafe(fieldValue) {
-		return "", UnsafeFieldError{fieldName}
+	err := allowSet.IsSafe(fieldValue)
+	if err != nil {
+		return "", UnsafeFieldError{fieldName, err.Error()}
 	}
 
 	return fieldValue, nil

--- a/handler.go
+++ b/handler.go
@@ -170,8 +170,9 @@ func GetVarSafe(r *http.Request, variableName string, allowSet AllowSet) (string
 		return "", MissingFieldError{variableName}
 	}
 
-	if !allowSet.IsSafe(variableValue) {
-		return "", UnsafeFieldError{variableName}
+	err := allowSet.IsSafe(variableValue)
+	if err != nil {
+		return "", UnsafeFieldError{variableName, err.Error()}
 	}
 
 	return variableValue, nil

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,10 +1,13 @@
 package scroll
 
-import "unicode"
+import (
+	"fmt"
+	"unicode"
+)
 
 // The AllowSet interface is implemented to detect if input is safe or not.
 type AllowSet interface {
-	IsSafe(string) bool
+	IsSafe(string) error
 }
 
 // AllowSetBytes allows the definition of a set of safe allowed ASCII characters.
@@ -25,18 +28,18 @@ func NewAllowSetBytes(s string, maxlen int) AllowSetBytes {
 	return AllowSetBytes{maxLen: maxlen, chars: as}
 }
 
-func (a AllowSetBytes) IsSafe(s string) bool {
+func (a AllowSetBytes) IsSafe(s string) error {
 	if len(s) > a.maxLen {
-		return false
+		return fmt.Errorf("length %v, longer then maximum allowable length: %v", len(s), a.maxLen)
 	}
 
 	for i := 0; i < len(s); i++ {
 		if a.chars[s[i]] == false {
-			return false
+			return fmt.Errorf("character %q (%v) not allowed", string(s[i]), s[i])
 		}
 	}
 
-	return true
+	return nil
 }
 
 // AllowSetStrings allows the definition of a set of safe allowed strings.
@@ -52,9 +55,9 @@ func NewAllowSetStrings(s []string) AllowSetStrings {
 	return AllowSetStrings{strings: m}
 }
 
-func (a AllowSetStrings) IsSafe(s string) bool {
+func (a AllowSetStrings) IsSafe(s string) error {
 	if _, ok := a.strings[s]; !ok {
-		return false
+		return fmt.Errorf("string %v not allowed", s)
 	}
-	return true
+	return nil
 }

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -9,44 +9,44 @@ var _ = fmt.Printf // for testing
 
 func TestAllowSetBytes(t *testing.T) {
 	tests := []struct {
-		inString string
-		inAllow  AllowSet
-		out      bool
+		inString        string
+		inAllow         AllowSet
+		outDidReturnErr bool
 	}{
 		// 0 - no match
 		{
 			"hello0",
 			NewAllowSetBytes(`0123456789`, 100),
-			false,
+			true,
 		},
 		// 1 - length (input length is one more than max)
 		{
 			"hello",
 			NewAllowSetBytes(`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`, 4),
-			false,
+			true,
 		},
 		// 2 - length (equal)
 		{
 			"hello",
 			NewAllowSetBytes(`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`, 5),
-			true,
+			false,
 		},
 		// 3 - length (input length is one less than max)
 		{
 			"hello",
 			NewAllowSetBytes(`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`, 6),
-			true,
+			false,
 		},
 		// 5 - all good
 		{
 			"hello, world",
 			NewAllowSetBytes(`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ, `, 100),
-			true,
+			false,
 		},
 	}
 
 	for i, tt := range tests {
-		if g, w := tt.inAllow.IsSafe(tt.inString), tt.out; g != w {
+		if g, w := parseError(tt.inAllow.IsSafe(tt.inString)), tt.outDidReturnErr; g != w {
 			t.Errorf("Test(%v), Got IsSafe: %v, Want: %v", i, g, w)
 		}
 	}
@@ -54,45 +54,52 @@ func TestAllowSetBytes(t *testing.T) {
 
 func TestAllowSetStrings(t *testing.T) {
 	tests := []struct {
-		inString string
-		inAllow  AllowSet
-		out      bool
+		inString        string
+		inAllow         AllowSet
+		outDidReturnErr bool
 	}{
 		// 0 - no match
 		{
 			"foo",
 			NewAllowSetStrings([]string{`bar`}),
-			false,
+			true,
 		},
 		// 1 - empty
 		{
 			"foo",
 			NewAllowSetStrings([]string{``}),
-			false,
+			true,
 		},
 		// 2 - one less
 		{
 			"foo",
 			NewAllowSetStrings([]string{`fo`}),
-			false,
+			true,
 		},
 		// 3 - one more
 		{
 			"foo",
 			NewAllowSetStrings([]string{`fooo`}),
-			false,
+			true,
 		},
 		// 4 - exact match
 		{
 			"foo",
 			NewAllowSetStrings([]string{`foo`}),
-			true,
+			false,
 		},
 	}
 
 	for i, tt := range tests {
-		if g, w := tt.inAllow.IsSafe(tt.inString), tt.out; g != w {
+		if g, w := parseError(tt.inAllow.IsSafe(tt.inString)), tt.outDidReturnErr; g != w {
 			t.Errorf("Test(%v), Got IsSafe: %v, Want: %v", i, g, w)
 		}
 	}
+}
+
+func parseError(err error) bool {
+	if err != nil {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
**Purpose**

Previously `IsSafe` would only return if input was safe or not, not the reason it was being rejected. The reason is useful for logging purposes so you know what the user was trying to validate that is invalid.

**Implementation**

* `IsSafe` function in `AllowSet` interface now returns a `error`.
* `AllowSetBytes` and `AllowSetStrings` now return descriptive errors.
* `UnsafeFieldError` now contains a `Description` field that contains the description of why something was unsafe.