### PR TITLE
Sync etcd cluster when creating a vulcan client

### DIFF
--- a/vulcan/client.go
+++ b/vulcan/client.go
@@ -23,6 +23,8 @@ type Client struct {
 func NewClient(key string) *Client {
 	etcd := etcd.NewClient([]string{etcdMachine})
 
+	etcd.SyncCluster()
+
 	return &Client{Key: key, etcd: etcd}
 }
 


### PR DESCRIPTION
I have found in the past that doing this improves the etcd client's
failover -- if a query fails, it now knows other machines it can try
before giving up.