### PR TITLE
Add RateLimitError that returns 429

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -64,6 +64,14 @@ func (e UnsafeFieldError) Error() string {
 	return fmt.Sprintf("field %q is unsafe: %v", e.Field, e.Description)
 }
 
+type RateLimitError struct {
+	Description string
+}
+
+func (e RateLimitError) Error() string {
+	return fmt.Sprintf("Rate Limited: %v. Try again later (and slower).", e.Description)
+}
+
 func responseAndStatusFor(err error) (Response, int) {
 	switch err.(type) {
 	case GenericAPIError, MissingFieldError, InvalidFormatError, InvalidParameterError, UnsafeFieldError:
@@ -72,6 +80,8 @@ func responseAndStatusFor(err error) (Response, int) {
 		return Response{"message": err.Error()}, http.StatusNotFound
 	case ConflictError:
 		return Response{"message": err.Error()}, http.StatusConflict
+	case RateLimitError:
+		return Response{"message": err.Error()}, http.StatusTooManyRequests
 	default:
 		return Response{"message": "Internal Server Error"}, http.StatusInternalServerError
 	}

--- a/handler.go
+++ b/handler.go
@@ -161,7 +161,7 @@ func ReplyError(w http.ResponseWriter, err error) {
 	Reply(w, response, status)
 }
 
-// Helper that replies with the 500 code and happened error message.
+// ReplyInternalError logs the error message and replies with a 500 status code.
 func ReplyInternalError(w http.ResponseWriter, message string) {
 	log.Errorf("Internal server error: %v", message)
 	Reply(w, Response{"message": message}, http.StatusInternalServerError)


### PR DESCRIPTION
**Purpose**

Allow scroll to return `429` when a client is being rate limited.

**Implementation**

Add `RateLimitError` which can will return `429` and the reason the request was rate limited.
