### PR TITLE
Now decoding url parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ _testmain.go
 
 *.exe
 *.test
+.idea/
+glide.lock
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: go
 go:
-  - 1.5.4
-  - 1.6.3
+  - 1.7.3
 install:
-  - go get github.com/coreos/etcd
-  - go get -t -v ./...
-  - go build -v ./...
+  - docker-compose up -d
+  - go get -u github.com/Masterminds/glide
+  - glide install
 script:
-  - etcd &
-  - go test -v ./...
-  - kill %1
-sudo: false
+  - go test $(glide novendor)
+  - docker-compose down
+sudo: required
+services:
+  - docker
 notifications:
   email: false

--- a/app.go
+++ b/app.go
@@ -69,6 +69,7 @@ func NewAppWithConfig(config AppConfig) (*App, error) {
 	app.router = config.Router
 	if app.router == nil {
 		app.router = mux.NewRouter()
+		app.router.UseEncodedPath()
 	}
 	app.router.HandleFunc("/_ping", handlePing).Methods("GET")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  etcd:
+    image: quay.io/coreos/etcd:v3.0.15
+    command: >
+        /usr/local/bin/etcd
+        -name etcd0
+        -advertise-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001
+        -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001
+        -initial-advertise-peer-urls http://0.0.0.0:2380
+        -listen-peer-urls http://0.0.0.0:2380
+        -initial-cluster-token etcd-cluster-1
+        -initial-cluster etcd0=http://0.0.0.0:2380
+        -initial-cluster-state new
+    ports:
+      - "2379:2379"
+      - "2380:2380"
+      - "4001:4001"

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,69 @@
+package: github.com/mailgun/scroll
+import:
+- package: github.com/coreos/etcd
+  version: ~3.0.15
+  subpackages:
+  - client
+- package: github.com/gorilla/mux
+  version: master
+- package: github.com/mailgun/iptools
+  version: master
+- package: github.com/mailgun/log
+  version: master
+- package: github.com/mailgun/manners
+  version: master
+- package: github.com/mailgun/metrics
+  version: master
+- package: github.com/coreos/go-semver
+  version: master
+  subpackages:
+  - semver
+- package: github.com/coreos/go-systemd
+  version: master
+  subpackages:
+  - daemon
+- package: github.com/coreos/pkg
+  version: master
+  subpackages:
+  - capnslog
+- package: github.com/stretchr/testify
+  version: master
+  subpackages:
+  - http
+- package: github.com/bgentry/speakeasy
+  version: master
+- package: github.com/dustin/go-humanize
+  version: master
+- package: github.com/olekukonko/tablewriter
+  version: master
+- package: github.com/mattn/go-runewidth
+  version: master
+- package: github.com/urfave/cli
+  version: master
+- package: github.com/kr/pty
+  version: master
+- package: gopkg.in/cheggaaa/pb.v1
+  version: master
+- package: github.com/akrennmair/gopcap
+  version: master
+- package: github.com/spacejam/loghisto
+  version: master
+- package: github.com/godbus/dbus
+  version: master
+- package: gopkg.in/yaml.v1
+  version: master
+- package: gopkg.in/tomb.v2
+  version: master
+- package: github.com/golang/glog
+  version: master
+- package: github.com/fatih/color
+  version: master
+- package: github.com/mattn/go-colorable
+  version: master
+- package: github.com/mattn/go-isatty
+  version: master
+- package: golang.org/x/net
+  subpackages:
+  - context
+testImport:
+- package: gopkg.in/check.v1

--- a/handler.go
+++ b/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -51,6 +52,19 @@ type Spec struct {
 	Logger func(format string, a ...interface{})
 }
 
+// Given a map of parameters url decode each parameter
+func DecodeParams(src map[string]string) map[string]string {
+	results := make(map[string]string, len(src))
+	for key, param := range src {
+		encoded, err := url.QueryUnescape(param)
+		if err != nil {
+			encoded = param
+		}
+		results[key] = encoded
+	}
+	return results
+}
+
 // Defines the signature of a handler function that can be registered by an app.
 //
 // The 3rd parameter is a map of variables extracted from the request path, e.g. if a request path was:
@@ -74,7 +88,7 @@ func MakeHandler(app *App, fn HandlerFunc, spec Spec) http.HandlerFunc {
 		}
 
 		start := time.Now()
-		response, err := fn(w, r, mux.Vars(r))
+		response, err := fn(w, r, DecodeParams(mux.Vars(r)))
 		elapsedTime := time.Since(start)
 
 		var status int


### PR DESCRIPTION
## Purpose
By default golang decodes any url encoding in the `Request.Path` string. This means a url such as `/v3/domain-id/tags/survey_2016%2F01%2F20` becomes `/v3/domain-id/tags/survey_2016/01/20` before passed to the multiplexer for routing.

Thus a route of `/v3/{domain}/tags/{tag:[^/]+}` will never match the url decoded request `/v3/domain-id/tags/survey_2016/01/20`.  Even if golang didn't decode the url and the route matched, the parameter of `{tag}` would still be url encoded as `survey_2016%2F01%2F20` which is not what our applications would expect. 

This Pull Request modifies scroll to allow matching on un-decoded url paths, and decodes the parameters before passing them to handlers.

## Implementation
When scroll calls `mux.NewRouter()` set `UseEncodedPath()` on the new router.
Added a method called `EncodeParams()` which encodes the url parameters matched by the multiplexer.
 