### PR TITLE
NewRegistry() config can now accept optional etcd.Config{}

### DIFF
--- a/vulcand/registry.go
+++ b/vulcand/registry.go
@@ -22,6 +22,7 @@ const (
 )
 
 type Config struct {
+	Etcd   *etcd.Config
 	Chroot string
 	TTL    time.Duration
 }
@@ -46,8 +47,12 @@ func NewRegistry(cfg Config, appname, ip string, port int) (*Registry, error) {
 		cfg.TTL = defaultRegistrationTTL
 	}
 
-	etcdCfg := etcd.Config{Endpoints: []string{localEtcdProxy}}
-	etcdClt, err := etcd.New(etcdCfg)
+	etcdConfig := cfg.Etcd
+	if etcdConfig == nil {
+		etcdConfig = &etcd.Config{Endpoints: []string{localEtcdProxy}}
+	}
+
+	etcdClt, err := etcd.New(*etcdConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Purpose
When developing on a non vagrant local machine the etcd endpoint is not always localhost. This setting will allow developers to specify the etcd endpoint

## Implementation
* Added `EtcdConfig *etcd.Config`  to `Config` struct
* Make constant `LocalEtcdProxy` public so services can access the default etcd endpoint in their code. 
```go
cfg.Vulcand = vulcand.Config{
	Etcd: &etcd.Config{
		Endpoints: []string{getEnv("ETCD_ENDPOINT", "127.0.0.1:9042")},
	},
}
appCfg.Vulcand = &cfg.Vulcand
app, err := scroll.NewAppWithConfig(appCfg)
```