### PR TITLE
LogRequest is now called whenever logging is needed

### DIFF
--- a/app.go
+++ b/app.go
@@ -66,6 +66,10 @@ func NewApp() (*App, error) {
 func NewAppWithConfig(config AppConfig) (*App, error) {
 	app := App{Config: config}
 
+	if LogRequest == nil {
+		LogRequest = logRequest
+	}
+
 	app.router = config.Router
 	if app.router == nil {
 		app.router = mux.NewRouter()
@@ -91,10 +95,6 @@ func NewAppWithConfig(config AppConfig) (*App, error) {
 // the handler will be registered in the local etcd instance.
 func (app *App) AddHandler(spec Spec) error {
 	var handler http.HandlerFunc
-
-	if spec.LogRequest == nil {
-		spec.LogRequest = logRequest
-	}
 
 	// make a handler depending on the function provided in the spec
 	if spec.RawHandler != nil {


### PR DESCRIPTION
## Purpose
scroll logging should be consistent

## Implementation
* Made `LogRequest` global to the package
* `LogRequest` is set during first call to `NewAppWithConfig()`
* `ReplyInternalError` and `parseForm` errors are now logged
