### PR TITLE
Timeouts and heartbeats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.7.3
+  - 1.8.1
 install:
   - docker-compose up -d
   - go get -u github.com/Masterminds/glide

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/mailgun/scroll"
-	"github.com/mailgun/scroll/registry"
 )
 
 func handler(w http.ResponseWriter, r *http.Request, params map[string]string) (interface{}, error) {
@@ -46,9 +46,14 @@ func main() {
 		Name:       "scrollexample",
 		ListenIP:   "0.0.0.0",
 		ListenPort: 8080,
-		Registry:   &registry.NopRegistry{},
+		PublicAPIHost:    "public.local",
+		ProtectedAPIHost: "private.local",
 	}
-	app := scroll.NewAppWithConfig(appConfig)
+	app, err := scroll.NewAppWithConfig(appConfig)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	// register a handler
 	handlerSpec := scroll.Spec{
@@ -60,6 +65,9 @@ func main() {
 	app.AddHandler(handlerSpec)
 
 	// start the app
-	app.Run()
+    if err = app.Run(); err != nil {
+        app.Stop() // Immediately un-register from vulcand
+        os.Exit(1)
+    }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ func main() {
 
 	app.AddHandler(handlerSpec)
 
-	// start the app
+	// Run the application
     if err = app.Run(); err != nil {
-        app.Stop() // Immediately un-register from vulcand
         os.Exit(1)
     }
 }

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ func main() {
 	app.AddHandler(handlerSpec)
 
 	// Run the application
-    if err = app.Run(); err != nil {
-        os.Exit(1)
-    }
+	if err = app.Run(); err != nil {
+		os.Exit(1)
+	}
 }
 ```

--- a/app.go
+++ b/app.go
@@ -133,7 +133,7 @@ func (app *App) AddHandler(spec Spec) error {
 			route.Headers(spec.Headers...)
 		}
 		if app.vulcandReg != nil {
-			app.registerFrontend(spec.Methods, path, spec.Scopes, spec.Middlewares)
+			app.registerFrontend(spec.Methods, path, spec.Scope, spec.Middlewares)
 		}
 	}
 
@@ -198,14 +198,12 @@ func (app *App) Run() error {
 }
 
 // registerLocation is a helper for registering handlers in vulcan.
-func (app *App) registerFrontend(methods []string, path string, scopes []Scope, middlewares []vulcand.Middleware) error {
-	for _, scope := range scopes {
-		host, err := app.apiHostForScope(scope)
-		if err != nil {
-			return err
-		}
-		app.vulcandReg.AddFrontend(host, path, methods, middlewares)
+func (app *App) registerFrontend(methods []string, path string, scope Scope, middlewares []vulcand.Middleware) error {
+	host, err := app.apiHostForScope(scope)
+	if err != nil {
+		return err
 	}
+	app.vulcandReg.AddFrontend(host, path, methods, middlewares)
 	return nil
 }
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -45,7 +45,6 @@ func main() {
 	}
 	app.AddHandler(handlerSpec)
 	if err = app.Run(); err != nil {
-		app.Stop() // Immediately un-register from vulcand
 		os.Exit(1)
 	}
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -44,7 +44,10 @@ func main() {
 		os.Exit(1)
 	}
 	app.AddHandler(handlerSpec)
-	app.Run()
+	if err = app.Run(); err != nil {
+		app.Stop() // Immediately un-register from vulcand
+		os.Exit(1)
+	}
 }
 
 func index(w http.ResponseWriter, r *http.Request, params map[string]string) (interface{}, error) {

--- a/examples/main.go
+++ b/examples/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	handlerSpec := scroll.Spec{
-		Scopes:  []scroll.Scope{scroll.ScopePublic, scroll.ScopeProtected},
+		Scope:   scroll.ScopePublic,
 		Methods: []string{"GET"},
 		Paths:   []string{"/"},
 		Handler: index,

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,8 +10,6 @@ import:
   version: master
 - package: github.com/mailgun/log
   version: master
-- package: github.com/mailgun/manners
-  version: master
 - package: github.com/mailgun/metrics
   version: master
 - package: github.com/coreos/go-semver

--- a/handler.go
+++ b/handler.go
@@ -46,11 +46,15 @@ type Spec struct {
 	MetricName string
 
 	// Controls the handler's accessibility via vulcan (public or protected). If not specified, public is assumed.
-	Scopes []Scope
+	Scope Scope
 
 	// Vulcan middlewares to register with the handler. When registering, middlewares are assigned priorities
 	// according to their positions in the list: a middleware that appears in the list earlier is executed first.
 	Middlewares []vulcand.Middleware
+
+	// When Handler or HandlerWithBody is used, this function will be called after every request with a log message.
+	// If nil, defaults to github.com/mailgun/log.Infof.
+	LogRequest func(r *http.Request, status int, elapsedTime time.Duration, err error)
 }
 
 // Given a map of parameters url decode each parameter

--- a/vulcand/backend.go
+++ b/vulcand/backend.go
@@ -14,21 +14,21 @@ type backendSpec struct {
 	URL     string
 }
 
-func newBackendSpec(appname, ip string, port int) (*backendSpec, error) {
+func newBackendSpec(appName, ip string, port int) (*backendSpec, error) {
 	id, err := makeEndpointID(port)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make endpoint ID: %v", err)
 	}
-	return newBackendSpecWithID(id, appname, ip, port)
+	return newBackendSpecWithID(id, appName, ip, port)
 }
 
-func newBackendSpecWithID(id string, appname string, ip string, port int) (*backendSpec, error) {
+func newBackendSpecWithID(id string, appName string, ip string, port int) (*backendSpec, error) {
 	url, err := makeEndpointURL(ip, port)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make endpoint URL: %v", err)
 	}
 	return &backendSpec{
-		AppName: appname,
+		AppName: appName,
 		ID:      id,
 		URL:     url,
 	}, nil

--- a/vulcand/frontend.go
+++ b/vulcand/frontend.go
@@ -36,7 +36,7 @@ func (fo frontendOptions) spec() string {
 	return fmt.Sprintf(`{"FailoverPredicate":"%s","PassHostHeader":%t}`, fo.FailoverPredicate, fo.PassHostHeader)
 }
 
-func newFrontendSpec(appname, host, path string, methods []string, middlewares []Middleware) *frontendSpec {
+func newFrontendSpec(appName, host, path string, methods []string, middlewares []Middleware) *frontendSpec {
 	path = normalizePath(path)
 	for i, m := range methods {
 		methods[i] = strings.ToUpper(m)
@@ -47,7 +47,7 @@ func newFrontendSpec(appname, host, path string, methods []string, middlewares [
 		Methods: methods,
 		URLPath: path,
 		Path:    makeLocationPath(methods, path),
-		AppName: appname,
+		AppName: appName,
 		Options: frontendOptions{
 			FailoverPredicate: defaultFailoverPredicate,
 			PassHostHeader:    defaultPassHostHeader,

--- a/vulcand/frontend_test.go
+++ b/vulcand/frontend_test.go
@@ -1,0 +1,63 @@
+package vulcand
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+)
+
+type FrontendSuite struct{}
+
+var _ = Suite(&FrontendSuite{})
+
+func (s *FrontendSuite) TestSpecAndHash(c *C) {
+	for i, tc := range []struct {
+		fes  *frontendSpec
+		spec string
+		hash string
+	}{{
+		fes:  newFrontendSpec("ghost", "example.com", "/v2/<domain>/events", []string{"GET"}, nil),
+		spec: `{"Type":"http","BackendId":"ghost","Route":"Host(\"example.com\") && Method(\"GET\") && Path(\"/v2/<domain>/events\")","Settings":{"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503) && Attempts() <= 2","PassHostHeader":true}}`,
+		hash: "cbbb3953754a6a1276e343754cf8eb288ac959dd",
+	}, {
+		fes:  newFrontendSpec("ghost", "exAMPle.com", "/v2/<domain>/events", []string{"GET"}, nil),
+		spec: `{"Type":"http","BackendId":"ghost","Route":"Host(\"example.com\") && Method(\"GET\") && Path(\"/v2/<domain>/events\")","Settings":{"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503) && Attempts() <= 2","PassHostHeader":true}}`,
+		hash: "cbbb3953754a6a1276e343754cf8eb288ac959dd",
+	}, {
+		fes:  newFrontendSpec("ghost", "example.com", "/v2/<domain>/events", []string{"get"}, nil),
+		spec: `{"Type":"http","BackendId":"ghost","Route":"Host(\"example.com\") && Method(\"GET\") && Path(\"/v2/<domain>/events\")","Settings":{"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503) && Attempts() <= 2","PassHostHeader":true}}`,
+		hash: "cbbb3953754a6a1276e343754cf8eb288ac959dd",
+	}, {
+		fes:  newFrontendSpec("ghostt", "example.com", "/v2/<domain>/events", []string{"GET"}, nil),
+		spec: `{"Type":"http","BackendId":"ghostt","Route":"Host(\"example.com\") && Method(\"GET\") && Path(\"/v2/<domain>/events\")","Settings":{"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503) && Attempts() <= 2","PassHostHeader":true}}`,
+		hash: "6671883acc37c3ea60df613d2a109a6d4ad5751a",
+	}, {
+		fes:  newFrontendSpec("ghost", "examplee.com", "/v2/<domain>/events", []string{"GET"}, nil),
+		spec: `{"Type":"http","BackendId":"ghost","Route":"Host(\"examplee.com\") && Method(\"GET\") && Path(\"/v2/<domain>/events\")","Settings":{"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503) && Attempts() <= 2","PassHostHeader":true}}`,
+		hash: "b5c6c2f3f22a6214267f3dbea4582fa9baa79765",
+	}, {
+		fes:  newFrontendSpec("ghost", "example.com", "/v2/<domai>/events", []string{"GET"}, nil),
+		spec: `{"Type":"http","BackendId":"ghost","Route":"Host(\"example.com\") && Method(\"GET\") && Path(\"/v2/<domai>/events\")","Settings":{"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503) && Attempts() <= 2","PassHostHeader":true}}`,
+		hash: "431965613ccb3debce7565b82b138e7dc6361d30",
+	}, {
+		fes:  newFrontendSpec("ghost", "example.com", "/v2/<domai>/events", []string{"POST"}, nil),
+		spec: `{"Type":"http","BackendId":"ghost","Route":"Host(\"example.com\") && Method(\"POST\") && Path(\"/v2/<domai>/events\")","Settings":{"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503) && Attempts() <= 2","PassHostHeader":true}}`,
+		hash: "d1f569bfba5e8004a76c3001029ee2fadf4ca3ec",
+	}, {
+		fes: newFrontendSpec("ghost", "example.com", "/v2/<domain>/events", []string{"GET"},
+			[]Middleware{{Type: "T1", ID: "Id1", Priority: 7}}),
+		spec: `{"Type":"http","BackendId":"ghost","Route":"Host(\"example.com\") && Method(\"GET\") && Path(\"/v2/<domain>/events\")","Settings":{"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503) && Attempts() <= 2","PassHostHeader":true}}`,
+		hash: "71baccfabc77c0bdaf63df4d9c8aa2408bf6f3f6",
+	}} {
+		fmt.Printf("Test case #%d\n", i)
+
+		// When
+		spec := tc.fes.spec()
+		hash, err := tc.fes.hash()
+
+		// Then
+		c.Assert(err, IsNil)
+		c.Assert(spec, Equals, tc.spec)
+		c.Assert(hash, Equals, tc.hash)
+	}
+}

--- a/vulcand/frontend_test.go
+++ b/vulcand/frontend_test.go
@@ -1,8 +1,6 @@
 package vulcand
 
 import (
-	"fmt"
-
 	. "gopkg.in/check.v1"
 )
 
@@ -49,7 +47,7 @@ func (s *FrontendSuite) TestSpecAndHash(c *C) {
 		spec: `{"Type":"http","BackendId":"ghost","Route":"Host(\"example.com\") && Method(\"GET\") && Path(\"/v2/<domain>/events\")","Settings":{"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503) && Attempts() <= 2","PassHostHeader":true}}`,
 		hash: "71baccfabc77c0bdaf63df4d9c8aa2408bf6f3f6",
 	}} {
-		fmt.Printf("Test case #%d\n", i)
+		c.Logf("Test case #%d", i)
 
 		// When
 		spec := tc.fes.spec()

--- a/vulcand/registry.go
+++ b/vulcand/registry.go
@@ -9,6 +9,7 @@ import (
 
 	etcd "github.com/coreos/etcd/client"
 	"github.com/mailgun/log"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -22,16 +23,15 @@ const (
 )
 
 type Config struct {
-	Etcd   *etcd.Config
 	Chroot string
 	TTL    time.Duration
 }
 
 type Registry struct {
 	cfg           Config
+	etcdKeysAPI   etcd.KeysAPI
 	backendSpec   *backendSpec
 	frontendSpecs []*frontendSpec
-	etcdKeysAPI   etcd.KeysAPI
 	ctx           context.Context
 	cancelFunc    context.CancelFunc
 	wg            sync.WaitGroup
@@ -40,21 +40,17 @@ type Registry struct {
 func NewRegistry(cfg Config, appName, ip string, port int) (*Registry, error) {
 	backendSpec, err := newBackendSpec(appName, ip, port)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create backend: err=(%s)", err)
+		return nil, errors.Wrap(err, "failed to create backend")
 	}
 
 	if cfg.TTL <= 0 {
 		cfg.TTL = defaultRegistrationTTL
 	}
 
-	etcdConfig := cfg.Etcd
-	if etcdConfig == nil {
-		etcdConfig = &etcd.Config{Endpoints: []string{localEtcdProxy}}
-	}
-
-	etcdClt, err := etcd.New(*etcdConfig)
+	etcdCfg := etcd.Config{Endpoints: []string{localEtcdProxy}}
+	etcdClt, err := etcd.New(etcdCfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to create Etcd client, cfg=%v", etcdCfg)
 	}
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	go func() {
@@ -63,7 +59,7 @@ func NewRegistry(cfg Config, appName, ip string, port int) (*Registry, error) {
 			if err == context.DeadlineExceeded || err == context.Canceled {
 				break
 			}
-			fmt.Print(err)
+			log.Errorf("Etcd auto sync failed: err=(%v)", err)
 		}
 	}()
 	etcdKeysAPI := etcd.NewKeysAPI(etcdClt)
@@ -82,11 +78,8 @@ func (r *Registry) AddFrontend(host, path string, methods []string, middlewares 
 }
 
 func (r *Registry) Start() error {
-	if err := r.registerBackendType(r.backendSpec); err != nil {
-		return fmt.Errorf("failed to register backend type: err=(%v)", err)
-	}
-	if err := r.registerBackendServer(r.backendSpec, r.cfg.TTL); err != nil {
-		return fmt.Errorf("failed to register backend server: err=(%v)", err)
+	if err := r.registerBackend(r.backendSpec); err != nil {
+		return errors.Wrapf(err, "failed to register backend, %s", r.backendSpec.ID)
 	}
 	r.wg.Add(1)
 	go r.heartbeat()
@@ -94,7 +87,7 @@ func (r *Registry) Start() error {
 	for _, fes := range r.frontendSpecs {
 		if err := r.registerFrontend(fes); err != nil {
 			r.cancelFunc()
-			return fmt.Errorf("failed to register frontend: err=(%v)", err)
+			return errors.Wrapf(err, "failed to register frontend, %s", fes.ID)
 		}
 	}
 	return nil
@@ -107,58 +100,60 @@ func (r *Registry) Stop() {
 
 func (r *Registry) heartbeat() {
 	defer r.wg.Done()
+	backendServerKey := fmt.Sprintf(serverFmt, r.cfg.Chroot, r.backendSpec.AppName, r.backendSpec.ID)
+	backendServerVal := r.backendSpec.serverSpec()
 	tick := time.NewTicker(r.cfg.TTL * 3 / 4)
 	for {
 		select {
 		case <-tick.C:
-			if err := r.registerBackendServer(r.backendSpec, r.cfg.TTL); err != nil {
-				log.Errorf("Heartbeat failed: err=(%v)", err)
+			_, err := r.etcdKeysAPI.Set(r.ctx, backendServerKey, "",
+				&etcd.SetOptions{PrevExist: etcd.PrevExist, Refresh: true, TTL: r.cfg.TTL})
+			if err != nil {
+				log.Errorf("Server TTL refresh failed: err=(%v)", err)
+				_, err := r.etcdKeysAPI.Set(r.ctx, backendServerKey, backendServerVal,
+					&etcd.SetOptions{TTL: r.cfg.TTL})
+				if err != nil {
+					log.Errorf("Server create failed: err=(%v)", err)
+				}
 			}
 		case <-r.ctx.Done():
-			err := r.removeBackendServer(r.backendSpec)
+			_, err := r.etcdKeysAPI.Delete(context.Background(), backendServerKey, nil)
 			log.Infof("Heartbeat stopped: err=(%v)", err)
 			return
 		}
 	}
 }
 
-func (r *Registry) registerBackendType(bes *backendSpec) error {
+func (r *Registry) registerBackend(bes *backendSpec) error {
 	betKey := fmt.Sprintf(backendFmt, r.cfg.Chroot, bes.AppName)
 	betVal := bes.typeSpec()
 	_, err := r.etcdKeysAPI.Set(r.ctx, betKey, betVal, nil)
-	return err
-}
-
-func (r *Registry) registerBackendServer(bes *backendSpec, ttl time.Duration) error {
+	if err != nil {
+		return errors.Wrapf(err, "failed to set backend type, %s", betKey)
+	}
 	besKey := fmt.Sprintf(serverFmt, r.cfg.Chroot, bes.AppName, bes.ID)
 	besVar := bes.serverSpec()
-	_, err := r.etcdKeysAPI.Set(r.ctx, besKey, besVar, &etcd.SetOptions{TTL: ttl})
-	return err
-}
-
-func (r *Registry) removeBackendServer(bes *backendSpec) error {
-	besKey := fmt.Sprintf(serverFmt, r.cfg.Chroot, bes.AppName, bes.ID)
-	_, err := r.etcdKeysAPI.Delete(context.Background(), besKey, nil)
-	return err
+	_, err = r.etcdKeysAPI.Set(r.ctx, besKey, besVar, &etcd.SetOptions{TTL: r.cfg.TTL})
+	return errors.Wrapf(err, "failed to set backend spec, %s", besKey)
 }
 
 func (r *Registry) registerFrontend(fes *frontendSpec) error {
-	feKey := fmt.Sprintf(frontendFmt, r.cfg.Chroot, fes.Host, fes.ID)
-	feVal := fes.spec()
-	_, err := r.etcdKeysAPI.Set(r.ctx, feKey, feVal, nil)
+	fesKey := fmt.Sprintf(frontendFmt, r.cfg.Chroot, fes.Host, fes.ID)
+	fesVal := fes.spec()
+	_, err := r.etcdKeysAPI.Set(r.ctx, fesKey, fesVal, nil)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to set frontend spec, %s", fesKey)
 	}
-	for i, m := range fes.Middlewares {
-		m.Priority = i
-		mwKey := fmt.Sprintf(middlewareFmt, r.cfg.Chroot, fes.Host, fes.ID, m.ID)
-		mwVal, err := json.Marshal(m)
+	for i, mw := range fes.Middlewares {
+		mw.Priority = i
+		mwKey := fmt.Sprintf(middlewareFmt, r.cfg.Chroot, fes.Host, fes.ID, mw.ID)
+		mwVal, err := json.Marshal(mw)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to JSON middleware, %v", mw)
 		}
 		_, err = r.etcdKeysAPI.Set(r.ctx, mwKey, string(mwVal), nil)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to set middleware, %s", mwKey)
 		}
 	}
 	return nil

--- a/vulcand/registry.go
+++ b/vulcand/registry.go
@@ -37,8 +37,8 @@ type Registry struct {
 	wg            sync.WaitGroup
 }
 
-func NewRegistry(cfg Config, appname, ip string, port int) (*Registry, error) {
-	backendSpec, err := newBackendSpec(appname, ip, port)
+func NewRegistry(cfg Config, appName, ip string, port int) (*Registry, error) {
+	backendSpec, err := newBackendSpec(appName, ip, port)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create backend: err=(%s)", err)
 	}

--- a/vulcand/registry.go
+++ b/vulcand/registry.go
@@ -23,6 +23,7 @@ const (
 )
 
 type Config struct {
+	Etcd   *etcd.Config
 	Chroot string
 	TTL    time.Duration
 }
@@ -47,8 +48,12 @@ func NewRegistry(cfg Config, appName, ip string, port int) (*Registry, error) {
 		cfg.TTL = defaultRegistrationTTL
 	}
 
-	etcdCfg := etcd.Config{Endpoints: []string{localEtcdProxy}}
-	etcdClt, err := etcd.New(etcdCfg)
+	etcdCfg := cfg.Etcd
+	if etcdCfg == nil {
+		etcdCfg = &etcd.Config{Endpoints: []string{localEtcdProxy}}
+	}
+
+	etcdClt, err := etcd.New(*etcdCfg)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create Etcd client, cfg=%v", etcdCfg)
 	}


### PR DESCRIPTION
- Vulcand heartbeat is performed via TTL update that does not trigger update watches on Vulcand;
- Manners is removed as obsolete by Golang 1.8;
- HTTP server Read/Write/Idle timeouts are set.