### PR TITLE
Preform a non blocking check on app.done before attempting to close

### DIFF
--- a/app.go
+++ b/app.go
@@ -221,9 +221,10 @@ func (app *App) Run() error {
 }
 
 func (app *App) Stop() {
-	if app.done != nil {
+	select {
+	case <-app.done:
+	default:
 		close(app.done)
-		app.done = nil
 	}
 }
 


### PR DESCRIPTION
Fixes a race condition introduced by #50 